### PR TITLE
fix: redesign control state with a state machine

### DIFF
--- a/drone_dji_sdk.orogen
+++ b/drone_dji_sdk.orogen
@@ -16,7 +16,6 @@ task_context "DroneFlightControlTask" do
     property "app_key", "/std/string", ""
     property "device", "/std/string", ""
     property "baudrate", "/uint32_t", 230_400
-    property "telemetry_mode", "/bool"
     property "pre_land_distance_threshold", "double", 1
     property "utm_parameters", "gps_base/UTMConversionParameters"
 

--- a/drone_dji_sdk.orogen
+++ b/drone_dji_sdk.orogen
@@ -30,7 +30,7 @@ task_context "DroneFlightControlTask" do
     output_port "cmd_out_position", "/std/vector</base/Vector3d>"
     output_port "status", "/drone_dji_sdk/Status"
 
-    runtime_states :DJI_STOPPED, :DJI_ON_GROUND, :DJI_IN_AIR, :CONTROL_LOST
+    runtime_states :TELEMETRY, :CONTROLLING, :CONTROL_LOST
 
     # Deployed with a 10ms period by default
     periodic 0.01

--- a/tasks/DroneFlightControlTask.cpp
+++ b/tasks/DroneFlightControlTask.cpp
@@ -101,6 +101,13 @@ void DroneFlightControlTask::updateHook()
         }
         return;
     }
+    else 
+    {
+        if (state() == CONTROL_LOST)
+        {
+            state(RUNNING);
+        }
+    }
 
     // Check status
     auto djiStatusFlight =

--- a/tasks/DroneFlightControlTask.hpp
+++ b/tasks/DroneFlightControlTask.hpp
@@ -109,7 +109,7 @@ namespace drone_dji_sdk
         void cleanupHook();
 
       private:
-        uint32_t mFunctionTimeout;
+        int64_t mFunctionTimeout;
         int mStatusFreqInHz;
         double mPositionThreshold;
         Vehicle::ActivateData mActivateData;

--- a/tasks/DroneFlightControlTask.hpp
+++ b/tasks/DroneFlightControlTask.hpp
@@ -3,22 +3,25 @@
 #ifndef DRONE_DJI_SDK_DRONEFLIGHTCONTROLTASK_TASK_HPP
 #define DRONE_DJI_SDK_DRONEFLIGHTCONTROLTASK_TASK_HPP
 
-#include "drone_dji_sdk/DroneFlightControlTaskBase.hpp"
-#include "drone_dji_sdkTypes.hpp"
-#include <gps_base/UTMConverter.hpp>
-#include <gps_base/BaseTypes.hpp>
+#include "djiosdk/dji_status.hpp"
 #include "djiosdk/dji_telemetry.hpp"
 #include "djiosdk/dji_vehicle.hpp"
-#include "djiosdk/dji_status.hpp"
+#include "drone_dji_sdk/DroneFlightControlTaskBase.hpp"
+#include "drone_dji_sdkTypes.hpp"
+#include <gps_base/BaseTypes.hpp>
+#include <gps_base/UTMConverter.hpp>
 
 namespace drone_dji_sdk
 {
 
     /*! \class DroneFlightControlTask
-     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
-     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
-     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
-     * 
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+     to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+     interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+     associated workflow.
+     *
      * \details
      * The name of a TaskContext is primarily defined via:
      \verbatim
@@ -26,19 +29,22 @@ namespace drone_dji_sdk
          task('custom_task_name','drone_dji_sdk::DroneFlightControlTask')
      end
      \endverbatim
-     *  It can be dynamically adapted when the deployment is called with a prefix argument.
+     *  It can be dynamically adapted when the deployment is called with a prefix
+     argument.
      */
     class DroneFlightControlTask : public DroneFlightControlTaskBase
     {
         friend class DroneFlightControlTaskBase;
 
-    protected:
-    public:
+      protected:
+      public:
         /** TaskContext constructor for DroneFlightControlTask
-         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
-         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState of
+         * the TaskContext. Default is Stopped state.
          */
-        DroneFlightControlTask(std::string const &name = "drone_dji_sdk::DroneFlightControlTask");
+        DroneFlightControlTask(
+            std::string const& name = "drone_dji_sdk::DroneFlightControlTask");
 
         /** Default deconstructor of DroneFlightControlTask
          */
@@ -102,8 +108,7 @@ namespace drone_dji_sdk
          */
         void cleanupHook();
 
-    private:
-
+      private:
         uint32_t mFunctionTimeout;
         int mStatusFreqInHz;
         double mPositionThreshold;
@@ -117,8 +122,10 @@ namespace drone_dji_sdk
         bool initVehicle();
         bool missionInitSettings(Mission wypMission);
         bool checkTelemetrySubscription();
-        bool setUpSubscription(int pkgIndex, int freq,
-                               std::vector<Telemetry::TopicName> topicList);
+        bool setUpSubscription(
+            int pkgIndex,
+            int freq,
+            std::vector<Telemetry::TopicName> topicList);
         bool teardownSubscription(const int pkgIndex);
 
         void posControl(VehicleSetpoint setpoint);
@@ -126,6 +133,9 @@ namespace drone_dji_sdk
         void land(VehicleSetpoint setpoint);
         void takeoff(VehicleSetpoint setpoint);
         void mission(Mission wypMission);
+
+        States runtimeStatesTransition();
+        void applyTransition(States next_state);
 
         // Helper Functions
         bool checkDistanceThreshold(drone_dji_sdk::VehicleSetpoint pos);
@@ -137,10 +147,10 @@ namespace drone_dji_sdk
 
         /**
          * Check if control over the drone if available for the SDK to obtain.
-         * 
+         *
          * @return whether the SDK can obtain control of the drone.
          */
         bool checkControlAvailability();
     };
-}
+} // namespace drone_dji_sdk
 #endif

--- a/tasks/DroneFlightControlTask.hpp
+++ b/tasks/DroneFlightControlTask.hpp
@@ -134,7 +134,7 @@ namespace drone_dji_sdk
         void takeoff(VehicleSetpoint setpoint);
         void mission(Mission wypMission);
 
-        States runtimeStatesTransition();
+        States runtimeStatesTransition(DJI::OSDK::Telemetry::SDKInfo control_device);
         void applyTransition(States next_state);
 
         // Helper Functions
@@ -146,11 +146,11 @@ namespace drone_dji_sdk
         WayPointSettings getWaypointSettings(Waypoint cmd_waypoint, int index);
 
         /**
-         * Check if control over the drone if available for the SDK to obtain.
+         * Check if the SDK can take the drone control authority.
          *
          * @return whether the SDK can obtain control of the drone.
          */
-        bool checkControlAvailability();
+        bool canTakeControl(DJI::OSDK::Telemetry::SDKInfo control_device);
     };
 } // namespace drone_dji_sdk
 #endif

--- a/tasks/DroneFlightControlTask.hpp
+++ b/tasks/DroneFlightControlTask.hpp
@@ -135,7 +135,9 @@ namespace drone_dji_sdk
         void mission(Mission wypMission);
 
         States runtimeStatesTransition(DJI::OSDK::Telemetry::SDKInfo control_device);
-        void applyTransition(States next_state);
+        void applyTransition(
+            States const& next_state,
+            DJI::OSDK::Telemetry::SDKInfo const& control_device);
 
         // Helper Functions
         bool checkDistanceThreshold(drone_dji_sdk::VehicleSetpoint pos);
@@ -150,7 +152,7 @@ namespace drone_dji_sdk
          *
          * @return whether the SDK can obtain control of the drone.
          */
-        bool canTakeControl(DJI::OSDK::Telemetry::SDKInfo control_device);
+        bool canTakeControl(DJI::OSDK::Telemetry::SDKInfo const& control_device);
     };
 } // namespace drone_dji_sdk
 #endif

--- a/tasks/DroneFlightControlTask.hpp
+++ b/tasks/DroneFlightControlTask.hpp
@@ -135,9 +135,7 @@ namespace drone_dji_sdk
         void mission(Mission wypMission);
 
         States runtimeStatesTransition(DJI::OSDK::Telemetry::SDKInfo control_device);
-        void applyTransition(
-            States const& next_state,
-            DJI::OSDK::Telemetry::SDKInfo const& control_device);
+        void applyTransition(States const& next_state);
 
         // Helper Functions
         bool checkDistanceThreshold(drone_dji_sdk::VehicleSetpoint pos);


### PR DESCRIPTION
If we run a control task alongside the telemetry task and then request control with the joystick, the control_lost event would trigger, finalizing the control task. But if we started a new control task without first restarting the telemetry task, it would stay in the control_lost state, triggering the event once again. 

To solve this, we implement a state machine with three states TELEMETRY, CONTROLLING and CONTROL_LOST. With the transition rules implemented here, we hope to have a stable control transition between the remote controller and the SDK.